### PR TITLE
fixing peerDependency to work with React 15+

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "webpack-hot-middleware": "^2.9.1"
   },
   "peerDependencies": {
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": ">=0.14.7",
+    "react-dom": ">=0.14.7"
   },
   "dependencies": {
     "d3-array": "^0.7.1",


### PR DESCRIPTION
Yet another PR that's probably gonna get forgotten here, just like react-d3/react-d3-basic#43
